### PR TITLE
Put quotes around value when writing to wallet

### DIFF
--- a/git-credential-with-kwallet
+++ b/git-credential-with-kwallet
@@ -105,7 +105,7 @@ end
 
 # Calls the writeEntry method. Used to store values in a wallet > folder.
 def write_entry(wallet_id, folder, key, value)
-  output = run_kwd5 "writeEntry #{wallet_id} #{folder} #{key} #{value} #{APP_NAME}"
+  output = run_kwd5 "writeEntry #{wallet_id} #{folder} #{key} '#{value}' #{APP_NAME}"
   if output == "0"
     vputs "Wrote (#{key} -> #{value}) to #{wallet_id} > #{folder}."
   else


### PR DESCRIPTION
Prevents errors when password contains special characters (e.g. '&')