### PR TITLE
Various fixes

### DIFF
--- a/git-credential-with-kwallet
+++ b/git-credential-with-kwallet
@@ -31,40 +31,48 @@ QDBUS_EXECUTABLES = ["qdbus", "qdbus-qt5", "qdbus6"]
 #     error checking. These functions abstract that work away from the control flow
 #     functions.
 
-# Using the qdbus org.kde.kwalletd5 /modules/kwalletd5, calls the provided method
-# with the provided arguments.
-def run_kwd5 command
-
-  success = false
-  output = nil
-  QDBUS_EXECUTABLES.each do |exe|
-    begin
-      output = `#{exe} org.kde.kwalletd5 /modules/kwalletd5 #{command}`.strip()
-    rescue Errno::ENOENT
-    else
-      success = true
-      break
-    end
-  end
-
-  if !success
-    STDERR.puts "Error: could not find any qdbus executables in PATH. Tried #{QDBUS_EXECUTABLES}"
-    exit(1)
-  end
-
-  if output == "Invalid number of parameters\n"
-    STDERR.puts "Error - invalid number of parameters. Ran: qdbus org.kde.kwalletd5 /modules/kwalletd5 #{command}"
-    exit(1)
-  end
-  
-  output
-end
-
 # puts the string if VERBOSE flag is true. Used for debugging.
 def vputs string
   if VERBOSE
     puts string
   end
+end
+
+# Returns true if the program executable is found in the user's path.
+def has_program?(program)
+  ENV['PATH'].split(File::PATH_SEPARATOR).any? do |directory|
+    File.executable?(File.join(directory, program))
+  end
+end
+
+# Finds the correct qdbus command
+def get_qdbus_command
+  QDBUS_EXECUTABLES.each do |exe|
+    if has_program?(exe)
+      vputs("Found qdbus command: '#{exe}'")
+      return exe 
+    end
+  end
+
+  STDERR.puts "Error: could not find any qdbus executables in PATH. Tried #{QDBUS_EXECUTABLES}"
+  exit(1)
+end
+
+QDBUS = get_qdbus_command()
+
+# Using the qdbus org.kde.kwalletd5 /modules/kwalletd5, calls the provided method
+# with the provided arguments.
+def run_kwd5 command
+  full_command = "#{QDBUS} org.kde.kwalletd5 /modules/kwalletd5 #{command}"
+  vputs("Running: #{full_command}")
+  output = `#{full_command}`.strip
+
+  if output == "Invalid number of parameters\n"
+    STDERR.puts "Error - invalid number of parameters. Ran: #{full_command}"
+    exit(1)
+  end
+
+  output
 end
 
 # Calls the createFolder method. Used to create a folder to store all the credentials

--- a/git-credential-with-kwallet
+++ b/git-credential-with-kwallet
@@ -20,7 +20,7 @@
 # 1. Global Variables
 #     Sets global variables which are used to configure the program.
 
-VERBOSE = false # VERBOSE = true can be used for debugging (git won't like it).
+VERBOSE = false # VERBOSE = true can be used for debugging to stderr.
 APP_NAME = "epwr-kwallet-git-credentials"
 KWALLET_FOLDER = "git-credentials"
 QDBUS_EXECUTABLES = ["qdbus", "qdbus-qt5", "qdbus6"]
@@ -34,7 +34,7 @@ QDBUS_EXECUTABLES = ["qdbus", "qdbus-qt5", "qdbus6"]
 # puts the string if VERBOSE flag is true. Used for debugging.
 def vputs string
   if VERBOSE
-    puts string
+    STDERR.puts string
   end
 end
 

--- a/git-credential-with-kwallet
+++ b/git-credential-with-kwallet
@@ -92,7 +92,7 @@ end
 # Calls the hasFolder method. Used to ensure that a folder exists when trying to
 # store a credential.
 def has_folder(wallet_id, folder)
-  run_kwd5 "hasFolder #{wallet_id} #{folder} #{APP_NAME}" == "true"
+  run_kwd5("hasFolder #{wallet_id} #{folder} #{APP_NAME}") == "true"
 end
 
 # Calls the folderList method. Used for debugging.


### PR DESCRIPTION
- Fixed `run_kwd5` call in `has_folder`.
  - Without the brackets it was comparing the two strings, then passing the result of that (false) to run_kwd5 (i.e. it was calling `run_kwd5(false)`)
  - With the brackets, it now calls `run_kwd5` with the correct parameters and compares the return value to `"true"`
- Find correct `qdbus` command in `$PATH` at startup.
  - I just upgraded to Debian 13 which uses qdbus6, and was getting a weird error "sh: 1: qdbus: not found".  After a bit of debugging, this only seemed to be happening when trying to store my credentials (all other `qdbus6` calls worked fine).  I think it may be to do with a non-alphanumeric character in my password.
  - It now looks up the correct qbdus command when the script starts up.
- Changed `vputs` to output to stderr, so it doesn't interfere with git.
